### PR TITLE
Add useNow hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ import {
   simpleObjectDifferent,
   simpleObjectValuesDifferent,
   Shape,
-  setState
+  setState,
+  useNow
 } from "set-state-compare"
 ```
 
@@ -208,6 +209,29 @@ function Example(props) {
   return React.createElement("div", null, String(shapeHook.state.count))
 }
 ```
+
+## useNow
+
+Runs a callback synchronously during render whenever its deps change. Fills the gap between `useMemo` (which fires twice under React 18 StrictMode when misused as an effect) and `useEffect` (which runs after commit, too late if you want work started immediately).
+
+```js
+import {useNow} from "set-state-compare"
+
+function Example({userId}) {
+  useNow(() => {
+    startLoadingUser(userId)
+  }, [userId])
+
+  // ...
+}
+```
+
+Semantics:
+- Runs during render, not after commit.
+- Fires exactly once per real dep change, even under StrictMode's double render pass (previous deps are tracked on a `useRef` that persists across the pass).
+- Dep comparison uses `arrayReferenceDifferent` — same per-element reference equality React uses for hook deps.
+- No cleanup phase. If the callback starts async work, cancel it inside the callback (e.g. with a request-id guard).
+- A full mount → unmount → remount cycle still re-fires, because the ref is fresh on the new mount. This matches `useMemo`.
 
 ## Comparison Utilities
 

--- a/spec/use-now-spec.js
+++ b/spec/use-now-spec.js
@@ -60,11 +60,13 @@ describe("useNow", () => {
 
   it("fires exactly once per dep change under StrictMode double render", () => {
     let calls = 0
+    let renderCount = 0
 
     /**
      * @returns {import("react").ReactElement}
      */
     function Component() {
+      renderCount += 1
       useNow(() => {
         calls += 1
       }, [])
@@ -78,6 +80,9 @@ describe("useNow", () => {
       )
     })
 
+    // StrictMode invokes the component body twice, but useNow should dedupe
+    // via the ref so the callback only fires once.
+    expect(renderCount).toBe(2)
     expect(calls).toBe(1)
   })
 })

--- a/spec/use-now-spec.js
+++ b/spec/use-now-spec.js
@@ -1,0 +1,83 @@
+import React, {StrictMode} from "react"
+import TestRenderer, {act} from "react-test-renderer"
+import useNow from "../src/use-now.js"
+
+describe("useNow", () => {
+  it("runs the callback during the initial render", () => {
+    let calls = 0
+
+    /**
+     * @returns {import("react").ReactElement}
+     */
+    function Component() {
+      useNow(() => {
+        calls += 1
+      }, [])
+
+      return React.createElement("div", null, String(calls))
+    }
+
+    act(() => {
+      TestRenderer.create(React.createElement(Component))
+    })
+
+    expect(calls).toBe(1)
+  })
+
+  it("re-runs only when deps change", () => {
+    let calls = 0
+
+    /**
+     * @param {{value: number}} props
+     * @returns {import("react").ReactElement}
+     */
+    function Component({value}) {
+      useNow(() => {
+        calls += 1
+      }, [value])
+
+      return React.createElement("div", null, String(value))
+    }
+
+    let renderer
+
+    act(() => {
+      renderer = TestRenderer.create(React.createElement(Component, {value: 1}))
+    })
+
+    act(() => {
+      renderer.update(React.createElement(Component, {value: 1}))
+    })
+
+    expect(calls).toBe(1)
+
+    act(() => {
+      renderer.update(React.createElement(Component, {value: 2}))
+    })
+
+    expect(calls).toBe(2)
+  })
+
+  it("fires exactly once per dep change under StrictMode double render", () => {
+    let calls = 0
+
+    /**
+     * @returns {import("react").ReactElement}
+     */
+    function Component() {
+      useNow(() => {
+        calls += 1
+      }, [])
+
+      return React.createElement("div", null, String(calls))
+    }
+
+    act(() => {
+      TestRenderer.create(
+        React.createElement(StrictMode, null, React.createElement(Component))
+      )
+    })
+
+    expect(calls).toBe(1)
+  })
+})

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import Shape from "./shape.js"
 import {ShapeHook, useShapeHook} from "./shape-hook.js"
 import shouldComponentUpdate from "./should-component-update.js"
 import setState from "./set-state.js"
+import useNow from "./use-now.js"
 
 export {
   anythingDifferent,
@@ -16,5 +17,6 @@ export {
   Shape,
   ShapeHook,
   setState,
+  useNow,
   useShapeHook
 }

--- a/src/use-now.js
+++ b/src/use-now.js
@@ -1,0 +1,25 @@
+import {arrayReferenceDifferent} from "./diff-utils.js"
+import {useRef} from "react"
+
+/**
+ * Runs `callback` synchronously during render whenever `deps` change.
+ *
+ * Unlike `useMemo`, the callback fires exactly once per real dep change even
+ * when React renders the component twice in StrictMode, because the previous
+ * deps are tracked on a ref that persists across the double render pass.
+ *
+ * Unlike `useEffect`, the callback runs during render (not after commit), so
+ * it kicks off work immediately instead of waiting for the next tick.
+ * @param {() => void} callback
+ * @param {Array<unknown>} deps
+ * @returns {void}
+ */
+export default function useNow(callback, deps) {
+  /** @type {import("react").MutableRefObject<Array<unknown> | null>} */
+  const prev = useRef(null)
+
+  if (prev.current === null || arrayReferenceDifferent(prev.current, deps)) {
+    prev.current = deps
+    callback()
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `useNow(callback, deps)`: runs `callback` synchronously during render whenever `deps` change.
- Dedupes StrictMode's double render pass via `useRef`, so the callback fires exactly once per real dep change.
- Reuses `arrayReferenceDifferent` from `diff-utils` for dep comparison (same `Object.is`-style semantics React uses for hook deps).

## Why
`useMemo` is sometimes (mis)used to kick off side effects synchronously during render, but StrictMode's double render pass fires the callback twice in dev — which can e.g. start two concurrent async loads. `useEffect` avoids that but runs after commit, which is too late when you want the work to start immediately.

`useNow` fills the gap: render-phase timing like `useMemo`, single-fire semantics like `useEffect`.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (72 specs, 0 failures; new spec covers initial render, dep-change re-run, and StrictMode single-fire)
