### PR TITLE
Add typed setInstance support to tt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,4 +3,5 @@
 - New code should be written with JSDoc comments.
 - Any new or added files should be checked with eslint after creation or changes.
 - Always run `npm run typecheck` as part of checks.
+- If you create a new branch for user work, you should almost always also create or update the matching PR unless the user explicitly says not to, or the branch is only for local throwaway investigation.
 - When creating PRs, use a proper multiline body (for example, `gh pr create --body-file - <<'EOF'` ... `EOF`) so newlines aren't escaped.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ export default shapeComponent(Counter)
 
 ### Typed Props and State
 
-`ShapeComponent` and `ShapeHook` support generic type parameters for props (`P`) and state (`S`) via JSDoc `@augments`. This gives you type-checked `this.props`, `this.p`, `this.state`, `this.s`, and `this.setState` calls.
+`ShapeComponent` and `ShapeHook` support generic type parameters for props (`P`), state (`S`), and injected instance helpers (`I`) via JSDoc `@augments`. This gives you type-checked `this.props`, `this.p`, `this.state`, `this.s`, and `this.setState` calls, with optional `this.tt` typing for values assigned through `setInstance(...)`.
 
 #### Typed props
 
@@ -160,12 +160,19 @@ Only registered top-level keys are writable — assigning to an undeclared key t
 
 #### Typed `this.tt`
 
-`this.tt` is a proxy of the instance that throws on unknown property reads. Typed as `this`, so JSX handlers like `onPress={this.tt.onFooPress}` are checked against the subclass's actual method signatures — typos fail typecheck, not just at runtime.
+`this.tt` is a proxy of the instance that throws on unknown property reads. It is typed as `this & I`, so JSX handlers like `onPress={this.tt.onFooPress}` stay checked against the subclass's actual methods, and apps that use `setInstance(...)` can opt into strict typings for injected helpers.
 
 ```js
+/** @augments {ShapeComponent<{}, {count: number}, {labelPrefix: string}>} */
 class Counter extends ShapeComponent {
+  state = /** @type {{count: number}} */ ({count: 0})
+
+  setup() {
+    this.setInstance({labelPrefix: "Count"})
+  }
+
   render() {
-    return React.createElement("button", {onPress: this.tt.onIncrementPress})
+    return React.createElement("button", {onPress: this.tt.onIncrementPress}, `${this.tt.labelPrefix}: ${this.s.count}`)
   }
 
   onIncrementPress = () => {

--- a/README.md
+++ b/README.md
@@ -53,15 +53,16 @@ Modes:
 - `Shape.setMode("setState")` uses `setState` on the component.
 
 ## ShapeComponent
-Class-style component wrapper with hooks-friendly state helpers.
-`setup()` runs before each render, so initialization in `setup()` is re-applied every render. It is also the recommended place to call hook-style helpers like `useState`/`useStates`.
+Class-style component wrapper with hook-like lifecycle helpers.
+`setup()` runs before each render, so it is suitable for derived values and render-time side work. Declare component state on the class-field `state` object.
 
 ```js
 import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 
 class Counter extends ShapeComponent {
+  state = {count: 0}
+
   render() {
-    this.useState("count", 0)
     return React.createElement("div", null, String(this.state.count))
   }
 }
@@ -71,7 +72,7 @@ export default shapeComponent(Counter)
 
 ### Typed Props and State
 
-`ShapeComponent` and `ShapeHook` support generic type parameters for props (`P`), state (`S`), and injected instance helpers (`I`) via JSDoc `@augments`. This gives you type-checked `this.props`, `this.p`, `this.state`, `this.s`, and `this.setState` calls, with optional `this.tt` typing for values assigned through `setInstance(...)`.
+`ShapeComponent` and `ShapeHook` support generic type parameters for props (`P`) and state (`S`) via JSDoc `@augments`. This gives you type-checked `this.props`, `this.p`, `this.state`, `this.s`, and `this.setState` calls.
 
 #### Typed props
 
@@ -84,8 +85,10 @@ export default shapeComponent(Counter)
 
 /** @augments {ShapeComponent<CounterProps>} */
 class Counter extends ShapeComponent {
-  setup() {
-    this.useStates({count: this.props.initialCount})
+  /** @param {CounterProps} props */
+  constructor(props) {
+    super(props)
+    this.state = {count: props.initialCount}
   }
 
   render() {
@@ -110,9 +113,7 @@ export default memo(shapeComponent(Counter))
 
 /** @augments {ShapeComponent<{}, TimerState>} */
 class Timer extends ShapeComponent {
-  setup() {
-    this.useStates({elapsed: 0, running: false})
-  }
+  state = /** @type {TimerState} */ ({elapsed: 0, running: false})
 
   render() {
     // this.state.elapsed -> number
@@ -125,7 +126,7 @@ class Timer extends ShapeComponent {
 
 #### Class field state
 
-State can also be defined as a class field instead of calling `useStates()`. The hooks are auto-registered from the class field keys.
+State is defined as a class field. The keys are auto-registered for `setState` and writable `this.s` access.
 
 ```js
 /** @augments {ShapeComponent<{name: string}, {label: string, active: boolean}>} */
@@ -160,19 +161,14 @@ Only registered top-level keys are writable — assigning to an undeclared key t
 
 #### Typed `this.tt`
 
-`this.tt` is a proxy of the instance that throws on unknown property reads. It is typed as `this & I`, so JSX handlers like `onPress={this.tt.onFooPress}` stay checked against the subclass's actual methods, and apps that use `setInstance(...)` can opt into strict typings for injected helpers.
+`this.tt` is a proxy of the instance that throws on unknown property reads. Typed as `this`, so JSX handlers like `onPress={this.tt.onFooPress}` are checked against the subclass's actual method signatures — typos fail typecheck, not just at runtime.
 
 ```js
-/** @augments {ShapeComponent<{}, {count: number}, {labelPrefix: string}>} */
 class Counter extends ShapeComponent {
   state = /** @type {{count: number}} */ ({count: 0})
 
-  setup() {
-    this.setInstance({labelPrefix: "Count"})
-  }
-
   render() {
-    return React.createElement("button", {onPress: this.tt.onIncrementPress}, `${this.tt.labelPrefix}: ${this.s.count}`)
+    return React.createElement("button", {onPress: this.tt.onIncrementPress}, String(this.s.count))
   }
 
   onIncrementPress = () => {
@@ -193,9 +189,7 @@ The same pattern works with `ShapeHook` and `useShapeHook`:
 
 /** @augments {ShapeHook<FormHookProps, {submitted: boolean}>} */
 class FormHook extends ShapeHook {
-  setup() {
-    this.useStates({submitted: false})
-  }
+  state = {submitted: false}
 }
 
 function FormHost(props) {
@@ -233,15 +227,13 @@ function Example(props) {
 ```
 
 ## useShapeHook
-Class-based hooks with `ShapeComponent`-style lifecycle methods like `setup`, `componentDidMount`, and `componentWillUnmount`.
+Class-based hooks with `ShapeComponent`-style lifecycle methods like `setup`, `componentDidMount`, and `componentWillUnmount`. Declare hook state on the class-field `state` object.
 
 ```js
 import useShapeHook, {ShapeHook} from "set-state-compare/build/shape-hook.js"
 
 class MyShapeHookClass extends ShapeHook {
-  setup() {
-    this.useState("count", 0)
-  }
+  state = {count: 0}
 }
 
 function Example(props) {

--- a/spec/generic-types-spec.js
+++ b/spec/generic-types-spec.js
@@ -53,9 +53,7 @@ describe("generic type forwarding", () => {
 
       /** @augments {ShapeHook<TypedProps>} */
       class TypedHook extends ShapeHook {
-        setup() {
-          this.useState("ready", false)
-        }
+        state = {ready: false}
       }
 
       /**
@@ -101,9 +99,7 @@ describe("generic type forwarding", () => {
 
       /** @augments {ShapeHook<{name: string}, TypedState>} */
       class StatefulHook extends ShapeHook {
-        setup() {
-          this.useStates({label: "hello", active: false})
-        }
+        state = /** @type {TypedState} */ ({label: "hello", active: false})
       }
 
       /**
@@ -188,48 +184,6 @@ describe("generic type forwarding", () => {
     })
   })
 
-  describe("ShapeComponent with typed setInstance values", () => {
-    it("allows tt typing to include injected instance helpers", () => {
-      /** @type {InstanceTypedComponent | undefined} */
-      let componentInstance
-
-      /**
-       * @augments {ShapeComponent<{name: string}, {active: boolean}, {labelPrefix: string}>}
-       */
-      class InstanceTypedComponent extends ShapeComponent {
-        state = /** @type {{active: boolean}} */ ({active: false})
-
-        setup() {
-          this.setInstance({labelPrefix: "Hello"})
-        }
-
-        render() {
-          componentInstance = this
-
-          return React.createElement("div", null, `${this.tt.labelPrefix}:${this.props.name}:${this.s.active}`)
-        }
-      }
-
-      const Component = shapeComponent(InstanceTypedComponent)
-      /** @type {import("react-test-renderer").ReactTestRenderer} */
-      let renderer
-
-      act(() => {
-        renderer = TestRenderer.create(React.createElement(Component, {name: "Louie"}))
-      })
-
-      act(() => {
-        flushAfterPaint()
-      })
-
-      expect(componentInstance.tt.labelPrefix).toBe("Hello")
-
-      act(() => {
-        renderer.unmount()
-      })
-    })
-  })
-
   describe("ShapeComponent with typed props and state via memo", () => {
     it("forwards prop types through memo(shapeComponent(...)) wrapper", () => {
       /** @type {MemoComponent | undefined} */
@@ -239,9 +193,7 @@ describe("generic type forwarding", () => {
        * @augments {ShapeComponent<TypedProps, TypedState>}
        */
       class MemoComponent extends ShapeComponent {
-        setup() {
-          this.useStates({label: "initial", active: true})
-        }
+        state = /** @type {TypedState} */ ({label: "initial", active: true})
 
         render() {
           componentInstance = this

--- a/spec/generic-types-spec.js
+++ b/spec/generic-types-spec.js
@@ -188,6 +188,48 @@ describe("generic type forwarding", () => {
     })
   })
 
+  describe("ShapeComponent with typed setInstance values", () => {
+    it("allows tt typing to include injected instance helpers", () => {
+      /** @type {InstanceTypedComponent | undefined} */
+      let componentInstance
+
+      /**
+       * @augments {ShapeComponent<{name: string}, {active: boolean}, {labelPrefix: string}>}
+       */
+      class InstanceTypedComponent extends ShapeComponent {
+        state = /** @type {{active: boolean}} */ ({active: false})
+
+        setup() {
+          this.setInstance({labelPrefix: "Hello"})
+        }
+
+        render() {
+          componentInstance = this
+
+          return React.createElement("div", null, `${this.tt.labelPrefix}:${this.props.name}:${this.s.active}`)
+        }
+      }
+
+      const Component = shapeComponent(InstanceTypedComponent)
+      /** @type {import("react-test-renderer").ReactTestRenderer} */
+      let renderer
+
+      act(() => {
+        renderer = TestRenderer.create(React.createElement(Component, {name: "Louie"}))
+      })
+
+      act(() => {
+        flushAfterPaint()
+      })
+
+      expect(componentInstance.tt.labelPrefix).toBe("Hello")
+
+      act(() => {
+        renderer.unmount()
+      })
+    })
+  })
+
   describe("ShapeComponent with typed props and state via memo", () => {
     it("forwards prop types through memo(shapeComponent(...)) wrapper", () => {
       /** @type {MemoComponent | undefined} */

--- a/spec/shape-component-spec.js
+++ b/spec/shape-component-spec.js
@@ -26,7 +26,6 @@ function flushAfterPaint() {
     callback()
   }
 }
-
 describe("shapeComponent", () => {
   beforeEach(() => {
     resetShared()
@@ -88,6 +87,11 @@ describe("shapeComponent", () => {
     let shapeInstance
 
     class TestShape extends ShapeComponent {
+      state = {
+        count: 0,
+        data: {name: "Donald"}
+      }
+
       /** @param {Record<string, any>} props */
       constructor(props) {
         super(props)
@@ -98,8 +102,6 @@ describe("shapeComponent", () => {
 
       render() {
         this.renderCount += 1
-        this.useState("count", 0)
-        this.useState("data", {name: "Donald"})
 
         return React.createElement("div", null, String(this.state.count))
       }
@@ -142,6 +144,8 @@ describe("shapeComponent", () => {
     let unmounted = 0
 
     class LifecycleShape extends ShapeComponent {
+      state = {count: 0}
+
       componentDidMount() {
         mounted += 1
       }
@@ -155,8 +159,6 @@ describe("shapeComponent", () => {
       }
 
       render() {
-        this.useState("count", 0)
-
         return React.createElement("div", null, "Lifecycle")
       }
     }
@@ -189,8 +191,9 @@ describe("shapeComponent", () => {
     let shapeInstance
 
     class TestShape extends ShapeComponent {
+      state = {count: 0}
+
       render() {
-        this.useState("count", 0)
         this.renderedCount = this.state.count
         shapeInstance = this
 
@@ -220,6 +223,30 @@ describe("shapeComponent", () => {
     expect(renderedCountSeenInDidUpdate).toBe(1)
   })
 
+  it("resolves function state defaults once during first registration", () => {
+    const initializer = jasmine.createSpy("initializer").and.returnValue(["a", "b"])
+
+    class LazyDefaultShape extends ShapeComponent {
+      state = {
+        items: initializer()
+      }
+
+      render() {
+        return React.createElement("div", null, String(this.state.items.length))
+      }
+    }
+
+    const Component = shapeComponent(LazyDefaultShape)
+    /** @type {import("react-test-renderer").ReactTestRenderer} */
+    let renderer
+
+    act(() => {
+      renderer = TestRenderer.create(React.createElement(Component))
+    })
+
+    expect(initializer.calls.count()).toBe(1)
+    expect(renderer.toJSON().children).toEqual(["2"])
+  })
   it("runs componentDidUpdate when props change with defaultProps", () => {
     let updates = 0
     /** @type {Record<string, any> | undefined} */
@@ -272,6 +299,8 @@ describe("shapeComponent", () => {
     let shapeInstance
 
     class DefaultPropsShape extends ShapeComponent {
+      state = {count: 2}
+
       /**
        * @param {Record<string, any>} prevProps
        * @param {Record<string, any>} prevState
@@ -282,7 +311,6 @@ describe("shapeComponent", () => {
       }
 
       render() {
-        this.useState("count", 2)
         shapeInstance = this
 
         return React.createElement("div", null, `${this.props.name}:${this.state.count}`)
@@ -331,6 +359,8 @@ describe("shapeComponent", () => {
     let shapeInstance
 
     class PropUpdateShape extends ShapeComponent {
+      state = {count: 0}
+
       componentDidUpdate(prevProps) {
         previousPropsCalls.push(prevProps)
 
@@ -340,7 +370,6 @@ describe("shapeComponent", () => {
       }
 
       render() {
-        this.useState("count", 0)
         shapeInstance = this
 
         return React.createElement("div", null, `${this.props.name}:${this.state.count}`)

--- a/spec/shape-component-spec.js
+++ b/spec/shape-component-spec.js
@@ -247,6 +247,7 @@ describe("shapeComponent", () => {
     expect(initializer.calls.count()).toBe(1)
     expect(renderer.toJSON().children).toEqual(["2"])
   })
+
   it("runs componentDidUpdate when props change with defaultProps", () => {
     let updates = 0
     /** @type {Record<string, any> | undefined} */

--- a/spec/shape-hook-spec.js
+++ b/spec/shape-hook-spec.js
@@ -39,9 +39,10 @@ describe("useShapeHook", () => {
 
     /** @augments {ShapeHook<{name: string}>} */
     class CounterHook extends ShapeHook {
+      state = {count: 0}
+
       setup() {
         setupCalls += 1
-        this.useState("count", 0)
       }
     }
 
@@ -92,6 +93,8 @@ describe("useShapeHook", () => {
 
     /** @augments {ShapeHook<{name: string}>} */
     class LifecycleHook extends ShapeHook {
+      state = {count: 0}
+
       componentDidMount() {
         mounted += 1
       }
@@ -102,10 +105,6 @@ describe("useShapeHook", () => {
 
       componentWillUnmount() {
         unmounted += 1
-      }
-
-      setup() {
-        this.useState("count", 0)
       }
     }
 
@@ -156,8 +155,9 @@ describe("useShapeHook", () => {
 
     /** @augments {ShapeHook<{name: string}>} */
     class MountedHook extends ShapeHook {
+      state = {count: 0}
+
       setup() {
-        this.useState("count", 0)
         mountedInSetup = this.isMounted()
         mountingInSetup = this.isMounting()
       }

--- a/src/shape-component.js
+++ b/src/shape-component.js
@@ -3,13 +3,14 @@ import {ShapeHook, useShapeHook} from "./shape-hook.js"
 /**
  * @template {Record<string, any>} [P=Record<string, any>]
  * @template {Record<string, any>} [S=Record<string, any>]
- * @augments {ShapeHook<P, S>}
+ * @template {Record<string, any>} [I=Record<string, any>]
+ * @augments {ShapeHook<P, S, I>}
  */
 class ShapeComponent extends ShapeHook {}
 
 /**
  * @template {Record<string, any>} P
- * @param {{defaultProps?: Record<string, any>, propTypes?: Record<string, import("prop-types").Validator<any>>, name: string} & (new (props: P) => ShapeComponent<P>)} ShapeClass
+ * @param {{defaultProps?: Record<string, any>, propTypes?: Record<string, import("prop-types").Validator<any>>, name: string} & (new (props: P) => ShapeComponent<P, any, any>)} ShapeClass
  * @returns {import("react").FunctionComponent<P>}
  */
 const shapeComponent = (ShapeClass) => {

--- a/src/shape-component.js
+++ b/src/shape-component.js
@@ -3,14 +3,13 @@ import {ShapeHook, useShapeHook} from "./shape-hook.js"
 /**
  * @template {Record<string, any>} [P=Record<string, any>]
  * @template {Record<string, any>} [S=Record<string, any>]
- * @template {Record<string, any>} [I=Record<string, any>]
- * @augments {ShapeHook<P, S, I>}
+ * @augments {ShapeHook<P, S>}
  */
 class ShapeComponent extends ShapeHook {}
 
 /**
  * @template {Record<string, any>} P
- * @param {{defaultProps?: Record<string, any>, propTypes?: Record<string, import("prop-types").Validator<any>>, name: string} & (new (props: P) => ShapeComponent<P, any, any>)} ShapeClass
+ * @param {{defaultProps?: Record<string, any>, propTypes?: Record<string, import("prop-types").Validator<any>>, name: string} & (new (props: P) => ShapeComponent<P, any>)} ShapeClass
  * @returns {import("react").FunctionComponent<P>}
  */
 const shapeComponent = (ShapeClass) => {

--- a/src/shape-hook.js
+++ b/src/shape-hook.js
@@ -18,6 +18,7 @@ import {useLayoutEffect, useMemo, useState} from "react"
 /**
  * @template {Record<string, any>} [P=Record<string, any>]
  * @template {Record<string, any>} [S=Record<string, any>]
+ * @template {Record<string, any>} [I=Record<string, any>]
  */
 class ShapeHook {
   /** @type {Record<string, any> | undefined} */
@@ -62,13 +63,12 @@ class ShapeHook {
     this.__firstRenderCompleted = false
     /**
      * Proxy for `this` that throws on unknown property reads. Typed as
-     * `this` so subclasses get correctly-typed access to their own
-     * methods and fields through `this.tt.someHandler` — the same
-     * narrowing approach used for `this.p` (`this["props"]`) and
-     * `this.s` (`this["state"]`).
-     * @type {this}
+     * `this & I` so subclasses can opt into strict `this.tt` typing for
+     * values assigned through `setInstance(...)`, while the default keeps
+     * `tt` permissive for apps that inject dynamic instance helpers.
+     * @type {this & I}
      */
-    this.tt = /** @type {this} */ (fetchingObject(this))
+    this.tt = /** @type {this & I} */ (fetchingObject(this))
 
     /**
      * Proxy for `this.props`. Typed as `this["props"]` so subclasses that
@@ -193,7 +193,7 @@ class ShapeHook {
   }
 
   /**
-   * @param {Record<string, any>} variables
+   * @param {Partial<I> & Record<string, any>} variables
    * @returns {void}
    */
   setInstance(variables) {

--- a/src/shape-hook.js
+++ b/src/shape-hook.js
@@ -18,7 +18,6 @@ import {useLayoutEffect, useMemo, useState} from "react"
 /**
  * @template {Record<string, any>} [P=Record<string, any>]
  * @template {Record<string, any>} [S=Record<string, any>]
- * @template {Record<string, any>} [I=Record<string, any>]
  */
 class ShapeHook {
   /** @type {Record<string, any> | undefined} */
@@ -63,12 +62,13 @@ class ShapeHook {
     this.__firstRenderCompleted = false
     /**
      * Proxy for `this` that throws on unknown property reads. Typed as
-     * `this & I` so subclasses can opt into strict `this.tt` typing for
-     * values assigned through `setInstance(...)`, while the default keeps
-     * `tt` permissive for apps that inject dynamic instance helpers.
-     * @type {this & I}
+     * `this` so subclasses get correctly-typed access to their own
+     * methods and fields through `this.tt.someHandler` — the same
+     * narrowing approach used for `this.p` (`this["props"]`) and
+     * `this.s` (`this["state"]`).
+     * @type {this}
      */
-    this.tt = /** @type {this & I} */ (fetchingObject(this))
+    this.tt = /** @type {this} */ (fetchingObject(this))
 
     /**
      * Proxy for `this.props`. Typed as `this["props"]` so subclasses that
@@ -86,9 +86,9 @@ class ShapeHook {
      * instead of falling back to the default `Record<string, any>`.
      *
      * Writable: `this.s.foo = value` is equivalent to
-     * `this.setState({foo: value})`. Only top-level state keys registered
-     * via class-field `state`, `useState`, or `useStates` are writable;
-     * assigning to an unregistered key throws. Nested mutation
+     * `this.setState({foo: value})`. Only top-level state keys declared on
+     * the class-field `state` object are writable; assigning to an
+     * unregistered key throws. Nested mutation
      * (`this.s.foo.bar = 1`) writes to the underlying state object but
      * does NOT schedule a re-render — call `this.setState` explicitly
      * for deep updates.
@@ -107,7 +107,7 @@ class ShapeHook {
         // inherited `Object.prototype` keys (`toString`, `constructor`, …)
         // and silently call those instead of failing on a typo.
         if (!Object.hasOwn(this.setStates, prop)) {
-          throw new Error(`Cannot assign to this.s.${prop} — state key "${prop}" is not registered. Declare it on the class-field state object, or call this.useState/useStates first.`)
+          throw new Error(`Cannot assign to this.s.${prop} — state key "${prop}" is not registered. Declare it on the class-field state object.`)
         }
         this.setStates[prop](newValue)
         return true
@@ -193,16 +193,6 @@ class ShapeHook {
   }
 
   /**
-   * @param {Partial<I> & Record<string, any>} variables
-   * @returns {void}
-   */
-  setInstance(variables) {
-    for (const name in variables) {
-      /** @type {Record<string, any>} */ (this)[name] = variables[name]
-    }
-  }
-
-  /**
    * @param {Partial<S> | ((state: S) => Partial<S>)} statesList
    * @param {function() : void} [callback]
    * @returns {void}
@@ -274,45 +264,6 @@ class ShapeHook {
   }
 
   /**
-   * Registers a state key. Idempotent — default applies only on first
-   * registration. Re-registering returns the existing setter; the
-   * default value is ignored on later calls.
-   * @param {string} stateName
-   * @param {any} [defaultValue]
-   * @returns {(newValue: any, args?: {silent?: boolean}) => void}
-   */
-  useState(stateName, defaultValue) {
-    if (Object.hasOwn(this.setStates, stateName)) {
-      return this.setStates[stateName]
-    }
-
-    const mutableState = /** @type {Record<string, any>} */ (this.state)
-
-    if (!(stateName in mutableState)) {
-      mutableState[stateName] = defaultValue
-    }
-
-    this.setStates[stateName] = (newValue, args) => {
-      if (!referenceDifferent(mutableState[stateName], newValue)) return
-
-      const lifecycle = /** @type {ShapeHookLifecycleHooks} */ (/** @type {unknown} */ (this))
-      const prevState = {...this.state}
-
-      mutableState[stateName] = newValue
-
-      if (args?.silent) return
-
-      if (lifecycle.componentDidUpdate) {
-        this.queueDidUpdate(this.__committedProps, prevState)
-      }
-
-      this.scheduleRender()
-    }
-
-    return this.setStates[stateName]
-  }
-
-  /**
    * Requests a re-render via the instance's update counter. Silent no-op
    * only after true teardown (not mounted and not mounting), so writes
    * after unmount do not trigger React warnings. Pre-mount and mid-render
@@ -336,23 +287,43 @@ class ShapeHook {
     this.__requestRender()
   }
 
-  /**
-   * @param {Array<string>|Record<string, any>} statesList
-   * @returns {void}
-   */
-  useStates(statesList) {
-    if (Array.isArray(statesList)) {
-      for(const stateName of statesList) {
-        this.useState(stateName)
-      }
-    } else {
-      for(const stateName in statesList) {
-        const defaultValue = statesList[stateName]
+}
 
-        this.useState(stateName, defaultValue)
-      }
-    }
+/**
+ * @param {ShapeHook<Record<string, any>, Record<string, any>>} shape
+ * @param {string} stateName
+ * @param {any} [defaultValue]
+ * @returns {(newValue: any, args?: {silent?: boolean}) => void}
+ */
+function registerShapeHookState(shape, stateName, defaultValue) {
+  if (Object.hasOwn(shape.setStates, stateName)) {
+    return shape.setStates[stateName]
   }
+
+  const mutableState = /** @type {Record<string, any>} */ (shape.state)
+
+  if (!(stateName in mutableState)) {
+    mutableState[stateName] = defaultValue
+  }
+
+  shape.setStates[stateName] = (newValue, stateArgs) => {
+    if (!referenceDifferent(mutableState[stateName], newValue)) return
+
+    const lifecycle = /** @type {ShapeHookLifecycleHooks} */ (/** @type {unknown} */ (shape))
+    const prevState = {...shape.state}
+
+    mutableState[stateName] = newValue
+
+    if (stateArgs?.silent) return
+
+    if (lifecycle.componentDidUpdate) {
+      shape.queueDidUpdate(shape.__committedProps, prevState)
+    }
+
+    shape.scheduleRender()
+  }
+
+  return shape.setStates[stateName]
 }
 
 /**
@@ -423,9 +394,9 @@ function useShapeHook(ShapeHookClass, props) {
     shape.props = actualProps
     const propsChanged = !memoCompareProps(prevProps, actualProps)
 
-    // Auto-register useState hooks for state keys defined as class fields.
+    // Auto-register state keys declared as class fields.
     for (const stateName of shape.__classFieldStateKeys) {
-      shape.useState(stateName, shape.state[stateName])
+      registerShapeHookState(shape, stateName, shape.state[stateName])
     }
 
     if (lifecycle.setup) {


### PR DESCRIPTION
## Summary\n- add a third generic parameter for ShapeHook/ShapeComponent instance values injected through setInstance(...)\n- type this.tt as this & I so strict tt typing remains opt-in instead of breaking dynamic consumers\n- cover the new behavior in the generic type spec and document the pattern in the README\n\n## Verification\n- npm run build\n- npm test\n- npm run typecheck