### PR TITLE
Preserve lazy state initializers

### DIFF
--- a/spec/shape-component-spec.js
+++ b/spec/shape-component-spec.js
@@ -220,6 +220,29 @@ describe("shapeComponent", () => {
     expect(renderedCountSeenInDidUpdate).toBe(1)
   })
 
+  it("resolves function state defaults once during first registration", () => {
+    const initializer = jasmine.createSpy("initializer").and.returnValue(["a", "b"])
+
+    class LazyDefaultShape extends ShapeComponent {
+      render() {
+        this.useState("items", initializer)
+
+        return React.createElement("div", null, String(this.state.items.length))
+      }
+    }
+
+    const Component = shapeComponent(LazyDefaultShape)
+    /** @type {import("react-test-renderer").ReactTestRenderer} */
+    let renderer
+
+    act(() => {
+      renderer = TestRenderer.create(React.createElement(Component))
+    })
+
+    expect(initializer.calls.count()).toBe(1)
+    expect(renderer.toJSON().children).toEqual(["2"])
+  })
+
   it("runs componentDidUpdate when props change with defaultProps", () => {
     let updates = 0
     /** @type {Record<string, any> | undefined} */

--- a/spec/use-shape-spec.js
+++ b/spec/use-shape-spec.js
@@ -83,6 +83,31 @@ describe("useShape", () => {
     expect(output.children).toEqual(["2"])
   })
 
+  it("resolves function state defaults once during first registration", () => {
+    const initializer = jasmine.createSpy("initializer").and.returnValue(["a", "b"])
+
+    /**
+     * @returns {import("react").ReactElement}
+     */
+    function UseShapeComponent() {
+      const shape = useShape({})
+
+      shape.useState("items", initializer)
+
+      return React.createElement("div", null, String(shape.state.items.length))
+    }
+
+    /** @type {import("react-test-renderer").ReactTestRenderer} */
+    let renderer
+
+    act(() => {
+      renderer = TestRenderer.create(React.createElement(UseShapeComponent))
+    })
+
+    expect(initializer.calls.count()).toBe(1)
+    expect(renderer.toJSON().children).toEqual(["2"])
+  })
+
   it("flushes deferred updates without a later React commit", async () => {
     /** @type {(value: number) => void} */
     let resolveAsyncUpdate

--- a/src/resolve-initial-state-value.js
+++ b/src/resolve-initial-state-value.js
@@ -1,0 +1,13 @@
+/**
+ * Preserve React's lazy-initializer semantics for function defaults while
+ * still storing the resolved value directly on local state.
+ * @param {any} defaultValue
+ * @returns {any}
+ */
+export default function resolveInitialStateValue(defaultValue) {
+  if (typeof defaultValue == "function") {
+    return defaultValue()
+  }
+
+  return defaultValue
+}

--- a/src/shape-hook.js
+++ b/src/shape-hook.js
@@ -4,6 +4,20 @@ import fetchingObject from "fetching-object"
 import memoCompareProps from "./memo-compare-props.js"
 import PropTypes from "prop-types"
 import shared from "./shared.js"
+
+/**
+ * Preserve React's lazy-initializer semantics for function defaults while
+ * still storing the resolved value directly on this.state.
+ * @param {any} defaultValue
+ * @returns {any}
+ */
+function resolveInitialStateValue(defaultValue) {
+  if (typeof defaultValue == "function") {
+    return defaultValue()
+  }
+
+  return defaultValue
+}
 import {useLayoutEffect, useMemo, useState} from "react"
 
 /**
@@ -289,7 +303,7 @@ class ShapeHook {
     const mutableState = /** @type {Record<string, any>} */ (this.state)
 
     if (!(stateName in mutableState)) {
-      mutableState[stateName] = defaultValue
+      mutableState[stateName] = resolveInitialStateValue(defaultValue)
     }
 
     this.setStates[stateName] = (newValue, args) => {

--- a/src/shape-hook.js
+++ b/src/shape-hook.js
@@ -3,21 +3,8 @@ import {dig} from "diggerize"
 import fetchingObject from "fetching-object"
 import memoCompareProps from "./memo-compare-props.js"
 import PropTypes from "prop-types"
+import resolveInitialStateValue from "./resolve-initial-state-value.js"
 import shared from "./shared.js"
-
-/**
- * Preserve React's lazy-initializer semantics for function defaults while
- * still storing the resolved value directly on this.state.
- * @param {any} defaultValue
- * @returns {any}
- */
-function resolveInitialStateValue(defaultValue) {
-  if (typeof defaultValue == "function") {
-    return defaultValue()
-  }
-
-  return defaultValue
-}
 import {useLayoutEffect, useMemo, useState} from "react"
 
 /**

--- a/src/use-shape.js
+++ b/src/use-shape.js
@@ -4,6 +4,20 @@ import fetchingObject from "fetching-object"
 import {shapeComponent} from "./shape-component.js"
 import shared from "./shared.js"
 
+/**
+ * Preserve React's lazy-initializer semantics for function defaults while
+ * still storing the resolved value directly on shape.state.
+ * @param {any} defaultValue
+ * @returns {any}
+ */
+function resolveInitialStateValue(defaultValue) {
+  if (typeof defaultValue == "function") {
+    return defaultValue()
+  }
+
+  return defaultValue
+}
+
 class UseShapeState {
   constructor() {
     this.__mounting = true
@@ -97,7 +111,7 @@ class UseShapeState {
     }
 
     if (!(stateName in this.state)) {
-      this.state[stateName] = defaultValue
+      this.state[stateName] = resolveInitialStateValue(defaultValue)
     }
 
     this.setStates[stateName] = (/** @type {any} */ newValue, /** @type {{silent?: boolean} | undefined} */ args) => {

--- a/src/use-shape.js
+++ b/src/use-shape.js
@@ -1,22 +1,9 @@
 import {referenceDifferent} from "./diff-utils.js"
+import resolveInitialStateValue from "./resolve-initial-state-value.js"
 import {useEffect, useMemo, useState} from "react"
 import fetchingObject from "fetching-object"
 import {shapeComponent} from "./shape-component.js"
 import shared from "./shared.js"
-
-/**
- * Preserve React's lazy-initializer semantics for function defaults while
- * still storing the resolved value directly on shape.state.
- * @param {any} defaultValue
- * @returns {any}
- */
-function resolveInitialStateValue(defaultValue) {
-  if (typeof defaultValue == "function") {
-    return defaultValue()
-  }
-
-  return defaultValue
-}
 
 class UseShapeState {
   constructor() {


### PR DESCRIPTION
## Summary
- preserve React-style lazy initializer behavior when `useState`/`useShape` receive a function default
- keep the `1.0.81` single-update-counter behavior while resolving initializer functions before storing them on state
- add regression specs covering function-valued defaults for both `ShapeComponent` and `useShape`

## Verification
- `npm test`
- `npm run typecheck`