### PR TITLE
Restore ShapeHook compatibility helpers

### DIFF
--- a/src/shape-hook.js
+++ b/src/shape-hook.js
@@ -3,6 +3,7 @@ import {dig} from "diggerize"
 import fetchingObject from "fetching-object"
 import memoCompareProps from "./memo-compare-props.js"
 import PropTypes from "prop-types"
+import resolveInitialStateValue from "./resolve-initial-state-value.js"
 import {enqueueRenderCallback, getRendering, scheduleAfterPaint, setRendering} from "./shared.js"
 import {useLayoutEffect, useMemo} from "react"
 import useState from "./use-state.js"
@@ -194,6 +195,19 @@ class ShapeHook {
   }
 
   /**
+   * Backward-compatible helper for populating instance fields in setup().
+   * Existing ShapeComponent consumers rely on `this.setInstance({...})`
+   * to attach route params, routers, refs, translations, and handlers.
+   * @param {Record<string, any>} variables
+   * @returns {void}
+   */
+  setInstance(variables) {
+    for (const name in variables) {
+      /** @type {Record<string, any>} */ (this)[name] = variables[name]
+    }
+  }
+
+  /**
    * @param {Partial<S> | ((state: S) => Partial<S>)} statesList
    * @param {function() : void} [callback]
    * @returns {void}
@@ -265,6 +279,37 @@ class ShapeHook {
   }
 
   /**
+   * Backward-compatible class-component state registration helper.
+   * Prefer class-field `state = {...}` for new code, but existing
+   * ShapeComponent consumers still call `this.useState(...)` in `setup()`
+   * and `render()`.
+   * @param {string} stateName
+   * @param {any} [defaultValue]
+   * @returns {(newValue: any, args?: {silent?: boolean}) => void}
+   */
+  useState(stateName, defaultValue) {
+    return registerShapeHookState(this, stateName, defaultValue, {resolveInitialValue: true})
+  }
+
+  /**
+   * Backward-compatible class-component state registration helper.
+   * Prefer class-field `state = {...}` for new code.
+   * @param {Array<string>|Record<string, any>} statesList
+   * @returns {void}
+   */
+  useStates(statesList) {
+    if (Array.isArray(statesList)) {
+      for(const stateName of statesList) {
+        this.useState(stateName)
+      }
+    } else {
+      for(const stateName in statesList) {
+        this.useState(stateName, statesList[stateName])
+      }
+    }
+  }
+
+  /**
    * Requests a re-render via the instance's update counter. Silent no-op
    * only after true teardown (not mounted and not mounting), so writes
    * after unmount do not trigger React warnings. Pre-mount and mid-render
@@ -294,9 +339,10 @@ class ShapeHook {
  * @param {ShapeHook<Record<string, any>, Record<string, any>>} shape
  * @param {string} stateName
  * @param {any} [defaultValue]
+ * @param {{resolveInitialValue?: boolean}} [options]
  * @returns {(newValue: any, args?: {silent?: boolean}) => void}
  */
-function registerShapeHookState(shape, stateName, defaultValue) {
+function registerShapeHookState(shape, stateName, defaultValue, options) {
   if (Object.hasOwn(shape.setStates, stateName)) {
     return shape.setStates[stateName]
   }
@@ -304,7 +350,7 @@ function registerShapeHookState(shape, stateName, defaultValue) {
   const mutableState = /** @type {Record<string, any>} */ (shape.state)
 
   if (!(stateName in mutableState)) {
-    mutableState[stateName] = defaultValue
+    mutableState[stateName] = options?.resolveInitialValue ? resolveInitialStateValue(defaultValue) : defaultValue
   }
 
   shape.setStates[stateName] = (newValue, stateArgs) => {


### PR DESCRIPTION
## Summary
- restore `ShapeHook#setInstance` for existing `ShapeComponent` consumers
- restore backward-compatible `useState` and `useStates` helpers
- preserve lazy initializer resolution for the compatibility path

## Validation
- `npm run build`
- `npm test`
- `npm run typecheck`