### PR TITLE
Add ShapeHook refresh lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Modes:
 
 ## ShapeComponent
 Class-style component wrapper with hook-like lifecycle helpers.
-`setup()` runs before each render, so it is suitable for derived values and render-time side work. Declare component state on the class-field `state` object.
+`setup()` runs before each render, so it is suitable for derived values and render-time side work. `refresh()` also runs before renders, but skips the first render where the constructor already ran. Declare component state on the class-field `state` object.
 
 ```js
 import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
@@ -227,7 +227,7 @@ function Example(props) {
 ```
 
 ## useShapeHook
-Class-based hooks with `ShapeComponent`-style lifecycle methods like `setup`, `componentDidMount`, and `componentWillUnmount`. Declare hook state on the class-field `state` object.
+Class-based hooks with `ShapeComponent`-style lifecycle methods like `setup`, `refresh`, `componentDidMount`, and `componentWillUnmount`. `setup()` runs before every render. `refresh()` runs before every render after the first one, which lets constructors initialize typed instance fields without duplicating first-render setup work. Declare hook state on the class-field `state` object.
 
 ```js
 import useShapeHook, {ShapeHook} from "set-state-compare/build/shape-hook.js"

--- a/changelog.d/20260427-shapehook-refresh.md
+++ b/changelog.d/20260427-shapehook-refresh.md
@@ -1,0 +1,1 @@
+Add `refresh()` to `ShapeHook`/`ShapeComponent` as a render-time lifecycle hook that skips the first render, so constructors can initialize typed instance fields without duplicating first-render setup work.

--- a/spec/shape-hook-spec.js
+++ b/spec/shape-hook-spec.js
@@ -89,6 +89,76 @@ describe("useShapeHook", () => {
     expect(setupCalls).toBe(3)
   })
 
+  it("runs refresh after the first render", () => {
+    let setupCalls = 0
+    let refreshCalls = 0
+
+    /** @augments {ShapeHook<{name: string}>} */
+    class RefreshHook extends ShapeHook {
+      state = {count: 0}
+
+      /**
+       * @returns {void}
+       */
+      setup() {
+        setupCalls += 1
+      }
+
+      /**
+       * @returns {void}
+       */
+      refresh() {
+        refreshCalls += 1
+      }
+    }
+
+    /**
+     * @param {{name: string}} props
+     * @returns {import("react").ReactElement}
+     */
+    function RefreshHost(props) {
+      const hook = useShapeHook(RefreshHook, props)
+
+      return React.createElement("button", {
+        onClick: () => hook.setState({count: hook.state.count + 1})
+      }, `${props.name}: ${hook.state.count}`)
+    }
+
+    /** @type {import("react-test-renderer").ReactTestRenderer} */
+    let renderer
+
+    act(() => {
+      renderer = TestRenderer.create(React.createElement(RefreshHost, {name: "Donald"}))
+    })
+
+    expect(setupCalls).toBe(1)
+    expect(refreshCalls).toBe(0)
+
+    act(() => {
+      flushAfterPaint()
+    })
+
+    act(() => {
+      renderer.update(React.createElement(RefreshHost, {name: "Daisy"}))
+    })
+
+    expect(setupCalls).toBe(2)
+    expect(refreshCalls).toBe(1)
+
+    act(() => {
+      flushAfterPaint()
+    })
+
+    const button = renderer.root.findByType("button")
+
+    act(() => {
+      button.props.onClick()
+    })
+
+    expect(setupCalls).toBe(3)
+    expect(refreshCalls).toBe(2)
+  })
+
   it("runs mount, update, and unmount hooks", () => {
     let mounted = 0
     let updated = 0

--- a/src/shape-hook.js
+++ b/src/shape-hook.js
@@ -14,6 +14,7 @@ import useState from "./use-state.js"
  * @property {() => void} [componentWillUnmount]
  * @property {{children: [import("react").ReactNode]}} props
  * @property {() => void} [setup]
+ * @property {() => void} [refresh]
  */
 
 /**
@@ -402,6 +403,10 @@ function useShapeHook(ShapeHookClass, props) {
 
     if (lifecycle.setup) {
       lifecycle.setup()
+    }
+
+    if (shape.__firstRenderCompleted && lifecycle.refresh) {
+      lifecycle.refresh()
     }
 
     if (lifecycle.componentDidUpdate && shape.__firstRenderCompleted && propsChanged) {


### PR DESCRIPTION
## Summary
- add `refresh()` as a ShapeHook/ShapeComponent lifecycle method that skips the first render
- document the `setup()` vs `refresh()` distinction
- add focused ShapeHook coverage and a changelog fragment

## Checks
- `npm test -- spec/shape-hook-spec.js`
- `npm run lint -- src/shape-hook.js spec/shape-hook-spec.js`
- `npm run typecheck`