### PR TITLE
[codex] Add ShapeHook hookField and hook guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Modes:
 
 ## ShapeComponent
 Class-style component wrapper with hook-like lifecycle helpers.
-`setup()` runs before each render, so it is suitable for derived values and render-time side work. `refresh()` also runs before renders, but skips the first render where the constructor already ran. Declare component state on the class-field `state` object.
+`setup()` runs before each render, so it is the only valid lifecycle site for React hooks. The constructor runs inside `useMemo` and may not call hooks. `refresh()` skips the first render and may not call hooks because doing so changes the hook count between the first and later renders. Declare component state on the class-field `state` object.
 
 ```js
 import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
@@ -68,6 +68,34 @@ class Counter extends ShapeComponent {
 }
 
 export default shapeComponent(Counter)
+```
+
+### Hook-Derived Fields
+
+Declare fields that are assigned from hooks with `this.hookField()`, then assign them in `setup()`. The initializer is typed as the field type for TypeScript, while still evaluating to `undefined` until `setup()` assigns the real value.
+
+```js
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
+import {useThemeColors, useThemeName} from "./theme-hooks.js"
+
+class Screen extends ShapeComponent {
+  /** @type {ReturnType<typeof useThemeColors>} */
+  colors = this.hookField()
+
+  /** @type {ReturnType<typeof useThemeName>} */
+  themeName = this.hookField()
+
+  setup() {
+    this.colors = useThemeColors()
+    this.themeName = useThemeName()
+  }
+
+  render() {
+    return React.createElement("div", {style: {color: this.colors.text}}, this.themeName)
+  }
+}
+
+export default shapeComponent(Screen)
 ```
 
 ### Typed Props and State
@@ -227,7 +255,7 @@ function Example(props) {
 ```
 
 ## useShapeHook
-Class-based hooks with `ShapeComponent`-style lifecycle methods like `setup`, `refresh`, `componentDidMount`, and `componentWillUnmount`. `setup()` runs before every render. `refresh()` runs before every render after the first one, which lets constructors initialize typed instance fields without duplicating first-render setup work. Declare hook state on the class-field `state` object.
+Class-based hooks with `ShapeComponent`-style lifecycle methods like `setup`, `refresh`, `componentDidMount`, and `componentWillUnmount`. `setup()` runs before every render and is the only valid lifecycle site for React hooks. Constructors run inside `useMemo` and may not call hooks. `refresh()` runs only after the first render and may not call hooks because it would add hooks on later renders that did not run on the first render. Declare hook state on the class-field `state` object.
 
 ```js
 import useShapeHook, {ShapeHook} from "set-state-compare/build/shape-hook.js"

--- a/changelog.d/20260429-shapehook-hook-field.md
+++ b/changelog.d/20260429-shapehook-hook-field.md
@@ -1,0 +1,1 @@
+Add `ShapeHook.hookField()` for setup-assigned hook fields, and add development-time guards that explain why hooks must move from ShapeHook constructors or `refresh()` into `setup()`.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint",
     "prepublishOnly": "npm run build",
     "test": "jasmine",
-    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.spec.json",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.spec.json && tsc --noEmit -p tsconfig.hook-field-spec.json",
     "watch": "tsc -w"
   },
   "repository": {

--- a/spec/hook-field-strict-property-initialization.ts
+++ b/spec/hook-field-strict-property-initialization.ts
@@ -1,0 +1,18 @@
+import {ShapeHook} from "../src/shape-hook.js"
+
+class HookFieldStrictPropertyInitializationProbe extends ShapeHook {
+  label: string = this.hookField()
+
+  setup(): void {
+    this.label = "ready"
+  }
+
+  readLabel(): string {
+    return this.label
+  }
+}
+
+const hookFieldStrictPropertyInitializationProbe = new HookFieldStrictPropertyInitializationProbe({})
+const label: string = hookFieldStrictPropertyInitializationProbe.readLabel()
+
+void label

--- a/spec/hook-field-typecheck.js
+++ b/spec/hook-field-typecheck.js
@@ -1,0 +1,45 @@
+// @ts-check
+import {ShapeHook} from "../src/shape-hook.js"
+
+/** @augments {ShapeHook<Record<string, never>, Record<string, never>>} */
+class HookFieldTypeProbe extends ShapeHook {
+  /** @type {string} */
+  label = this.hookField()
+
+  /** @type {number} */
+  count = this.hookField()
+
+  /**
+   * @returns {void}
+   */
+  setup() {
+    this.label = "ready"
+    this.count = 1
+  }
+
+  /**
+   * @returns {string}
+   */
+  readLabel() {
+    return this.label
+  }
+
+  /**
+   * @returns {number}
+   */
+  readCount() {
+    return this.count
+  }
+}
+
+const hookFieldTypeProbe = new HookFieldTypeProbe({})
+
+hookFieldTypeProbe.setup()
+
+/** @type {string} */
+const label = hookFieldTypeProbe.readLabel()
+/** @type {number} */
+const count = hookFieldTypeProbe.readCount()
+
+void label
+void count

--- a/spec/shape-hook-spec.js
+++ b/spec/shape-hook-spec.js
@@ -5,7 +5,7 @@ import {
   setAfterPaintHandle
 } from "../src/shared.js"
 
-import React from "react"
+import React, {useState as reactUseState} from "react"
 import TestRenderer, {act} from "react-test-renderer"
 import {ShapeHook, useShapeHook} from "../src/shape-hook.js"
 
@@ -33,6 +33,144 @@ function flushAfterPaint() {
 describe("useShapeHook", () => {
   beforeEach(() => {
     resetShared()
+  })
+
+  it("throws a clear error when a hook is called from the constructor", () => {
+    class ConstructorHook extends ShapeHook {
+      /**
+       * @param {Record<string, never>} props
+       */
+      constructor(props) {
+        super(props)
+        reactUseState(0)
+      }
+    }
+
+    /**
+     * @returns {import("react").ReactElement}
+     */
+    function ConstructorHost() {
+      useShapeHook(ConstructorHook, {})
+
+      return React.createElement("div", null, "Constructor")
+    }
+
+    expect(() => {
+      act(() => {
+        TestRenderer.create(React.createElement(ConstructorHost))
+      })
+    }).toThrowError(/React hooks cannot be called from ConstructorHook's constructor.*setup\(\)/)
+  })
+
+  it("throws a clear error when a hook is called from refresh", () => {
+    /** @augments {ShapeHook<{name: string}>} */
+    class RefreshHook extends ShapeHook {
+      /**
+       * @returns {void}
+       */
+      refresh() {
+        reactUseState(0)
+      }
+    }
+
+    /**
+     * @param {{name: string}} props
+     * @returns {import("react").ReactElement}
+     */
+    function RefreshHost(props) {
+      useShapeHook(RefreshHook, props)
+
+      return React.createElement("div", null, props.name)
+    }
+
+    /** @type {import("react-test-renderer").ReactTestRenderer} */
+    let renderer
+
+    act(() => {
+      renderer = TestRenderer.create(React.createElement(RefreshHost, {name: "Donald"}))
+    })
+
+    act(() => {
+      flushAfterPaint()
+    })
+
+    expect(() => {
+      act(() => {
+        renderer.update(React.createElement(RefreshHost, {name: "Daisy"}))
+      })
+    }).toThrowError(/React hooks cannot be called from RefreshHook\.refresh\(\).*setup\(\)/)
+  })
+
+  it("allows hooks from setup and re-runs them on every render", () => {
+    /** @type {SetupStateHook | undefined} */
+    let hookInstance
+    let setupCalls = 0
+    /** @type {number[]} */
+    const setupCounts = []
+
+    /** @augments {ShapeHook<{name: string}>} */
+    class SetupStateHook extends ShapeHook {
+      /** @type {number} */
+      count = this.hookField()
+
+      /** @type {(newValue: number | ((previousState: number) => number)) => void} */
+      setCount = this.hookField()
+
+      /**
+       * @returns {void}
+       */
+      setup() {
+        const [count, setCount] = reactUseState(0)
+
+        setupCalls += 1
+        setupCounts.push(count)
+        this.count = count
+        this.setCount = setCount
+      }
+    }
+
+    /**
+     * @param {{name: string}} props
+     * @returns {import("react").ReactElement}
+     */
+    function SetupStateHost(props) {
+      const hook = useShapeHook(SetupStateHook, props)
+
+      hookInstance = hook
+
+      return React.createElement("div", null, `${props.name}:${hook.count}`)
+    }
+
+    /** @type {import("react-test-renderer").ReactTestRenderer} */
+    let renderer
+
+    act(() => {
+      renderer = TestRenderer.create(React.createElement(SetupStateHost, {name: "Donald"}))
+    })
+
+    expect(renderer.toJSON().children).toEqual(["Donald:0"])
+
+    act(() => {
+      flushAfterPaint()
+    })
+
+    act(() => {
+      renderer.update(React.createElement(SetupStateHost, {name: "Daisy"}))
+    })
+
+    expect(renderer.toJSON().children).toEqual(["Daisy:0"])
+
+    act(() => {
+      flushAfterPaint()
+    })
+
+    act(() => {
+      hookInstance.setCount((previousCount) => previousCount + 1)
+    })
+
+    expect(renderer.toJSON().children).toEqual(["Daisy:1"])
+    expect(setupCalls).toBe(3)
+    expect(setupCounts).toEqual([0, 0, 1])
   })
 
   it("supports setup with class-based hook state", () => {

--- a/src/shape-hook.js
+++ b/src/shape-hook.js
@@ -3,7 +3,14 @@ import {dig} from "diggerize"
 import fetchingObject from "fetching-object"
 import memoCompareProps from "./memo-compare-props.js"
 import PropTypes from "prop-types"
-import {enqueueRenderCallback, getRendering, scheduleAfterPaint, setRendering} from "./shared.js"
+import {
+  assertShapeHookLifecycleSupportsHooks,
+  enqueueRenderCallback,
+  getRendering,
+  scheduleAfterPaint,
+  setRendering,
+  withShapeHookLifecycle
+} from "./shared.js"
 import {useLayoutEffect, useMemo} from "react"
 import useState from "./use-state.js"
 
@@ -195,6 +202,21 @@ class ShapeHook {
   }
 
   /**
+   * Declares an instance field that will be assigned during `setup()`.
+   * Returns `undefined` at construction time but is typed as `T` so
+   * TypeScript treats the field as definitely assigned. Pair every usage
+   * with an assignment in `setup()` — reading the field before `setup()`
+   * runs will surface as `undefined` (the framework calls `setup()`
+   * before `render()` on every render, so reads inside `render()` are safe).
+   * @protected
+   * @template T
+   * @returns {T}
+   */
+  hookField() {
+    return /** @type {T} */ (/** @type {unknown} */ (undefined))
+  }
+
+  /**
    * @param {Partial<S> | ((state: S) => Partial<S>)} statesList
    * @param {function() : void} [callback]
    * @returns {void}
@@ -336,6 +358,8 @@ function registerShapeHookState(shape, stateName, defaultValue) {
  * @returns {T}
  */
 function useShapeHook(ShapeHookClass, props) {
+  assertShapeHookLifecycleSupportsHooks("useShapeHook")
+
   // One counter per component drives all re-renders; state values live on
   // the instance (this.state) so writes after unmount can update silently.
   const [, setUpdateCount] = useState(0)
@@ -379,7 +403,10 @@ function useShapeHook(ShapeHookClass, props) {
     }
 
     const shape = useMemo(() => {
-      const instance = new ShapeHookClass(actualProps)
+      const instance = withShapeHookLifecycle(
+        {name: "constructor", className: ShapeHookClass.name},
+        () => new ShapeHookClass(actualProps)
+      )
 
       // Snapshot state keys defined as class fields (before setup adds more).
       instance.__classFieldStateKeys = Object.keys(instance.state)
@@ -402,11 +429,17 @@ function useShapeHook(ShapeHookClass, props) {
     }
 
     if (lifecycle.setup) {
-      lifecycle.setup()
+      withShapeHookLifecycle(
+        {name: "setup", className: ShapeHookClass.name},
+        () => lifecycle.setup?.()
+      )
     }
 
     if (shape.__firstRenderCompleted && lifecycle.refresh) {
-      lifecycle.refresh()
+      withShapeHookLifecycle(
+        {name: "refresh", className: ShapeHookClass.name},
+        () => lifecycle.refresh?.()
+      )
     }
 
     if (lifecycle.componentDidUpdate && shape.__firstRenderCompleted && propsChanged) {

--- a/src/shared.js
+++ b/src/shared.js
@@ -9,6 +9,15 @@ let afterPaintHandle = undefined
 const renderingKey = Symbol.for("set-state-compare/rendering")
 /** @type {typeof globalThis & Record<symbol, unknown>} */
 const sharedGlobal = globalThis
+/** @typedef {"constructor" | "setup" | "refresh"} ShapeHookLifecycleName */
+/**
+ * @typedef {object} ShapeHookLifecycleFrame
+ * @property {ShapeHookLifecycleName} name
+ * @property {string} className
+ */
+/** @type {ShapeHookLifecycleFrame | undefined} */
+let currentShapeHookLifecycle = undefined
+const shapeHookLifecycleErrorKey = Symbol.for("set-state-compare/shape-hook-lifecycle-error")
 
 if (typeof sharedGlobal[renderingKey] !== "number") {
   sharedGlobal[renderingKey] = 0
@@ -40,6 +49,153 @@ function defaultDeferredCallbackErrorReporter(errors) {
 
 /** @type {(errors: unknown[]) => void} */
 let deferredCallbackErrorReporter = defaultDeferredCallbackErrorReporter
+
+/** @returns {boolean} */
+function isProductionRuntime() {
+  const runtimeGlobal = /** @type {typeof globalThis & {__DEV__?: boolean, process?: {env?: {NODE_ENV?: string}}}} */ (globalThis)
+
+  return runtimeGlobal.process?.env?.NODE_ENV === "production" || runtimeGlobal.__DEV__ === false
+}
+
+/**
+ * @param {string} hookName
+ * @param {ShapeHookLifecycleFrame} lifecycle
+ * @returns {Error}
+ */
+function buildShapeHookLifecycleHookError(hookName, lifecycle) {
+  /** @type {Error} */
+  let error
+
+  if (lifecycle.name == "constructor") {
+    error = new Error(`${hookName} cannot be called from ${lifecycle.className}'s constructor. ShapeHook constructors run inside React.useMemo, so hooks there violate React's rules of hooks. Move the hook call to setup(), which runs unconditionally on every render before render(). For hook-derived fields, declare the field with this.hookField() and assign it in setup().`)
+  } else {
+    error = new Error(`${hookName} cannot be called from ${lifecycle.className}.refresh(). ShapeHook.refresh() skips the first render, so hooks there change the hook count between the first and later renders. Move the hook call to setup(), which runs unconditionally on every render before render().`)
+  }
+
+  /** @type {Error & Record<symbol, boolean>} */ (error)[shapeHookLifecycleErrorKey] = true
+
+  return error
+}
+
+/**
+ * @param {unknown} error
+ * @returns {boolean}
+ */
+function isShapeHookLifecycleHookError(error) {
+  return Boolean(
+    error &&
+    typeof error == "object" &&
+    shapeHookLifecycleErrorKey in error
+  )
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string | undefined}
+ */
+function errorMessageFor(value) {
+  if (value instanceof Error) return value.message
+  if (typeof value == "string") return value
+
+  return undefined
+}
+
+/**
+ * @param {string} message
+ * @returns {boolean}
+ */
+function isReactHookLifecycleMessage(message) {
+  return (
+    /Do not call Hooks inside/.test(message) ||
+    /Invalid hook call/.test(message) ||
+    /React has detected a change in the order of Hooks called/.test(message) ||
+    /Rendered more hooks than during the previous render/.test(message) ||
+    /Rendered fewer hooks than expected/.test(message) ||
+    /Should have a queue\. You are likely calling Hooks conditionally/.test(message)
+  )
+}
+
+/**
+ * @param {unknown} error
+ * @returns {boolean}
+ */
+function isReactHookLifecycleError(error) {
+  const message = errorMessageFor(error)
+
+  return Boolean(message && isReactHookLifecycleMessage(message))
+}
+
+/**
+ * @param {ShapeHookLifecycleFrame} lifecycle
+ * @returns {(() => void) | undefined}
+ */
+function installShapeHookLifecycleConsoleGuard(lifecycle) {
+  if (isProductionRuntime()) return undefined
+  if (lifecycle.name == "setup") return undefined
+
+  const previousConsoleError = console.error
+
+  console.error = (...args) => {
+    const hasReactHookWarning = args.some((arg) => {
+      const message = errorMessageFor(arg)
+
+      return Boolean(message && isReactHookLifecycleMessage(message))
+    })
+
+    if (hasReactHookWarning) {
+      throw buildShapeHookLifecycleHookError("React hooks", lifecycle)
+    }
+
+    previousConsoleError.apply(console, args)
+  }
+
+  return () => {
+    console.error = previousConsoleError
+  }
+}
+
+/**
+ * @template T
+ * @param {ShapeHookLifecycleFrame} lifecycle
+ * @param {() => T} callback
+ * @returns {T}
+ */
+export function withShapeHookLifecycle(lifecycle, callback) {
+  const previousLifecycle = currentShapeHookLifecycle
+  const restoreConsoleGuard = installShapeHookLifecycleConsoleGuard(lifecycle)
+
+  currentShapeHookLifecycle = lifecycle
+
+  try {
+    return callback()
+  } catch (error) {
+    if (
+      !isProductionRuntime() &&
+      lifecycle.name != "setup" &&
+      !isShapeHookLifecycleHookError(error) &&
+      isReactHookLifecycleError(error)
+    ) {
+      throw buildShapeHookLifecycleHookError("React hooks", lifecycle)
+    }
+
+    throw error
+  } finally {
+    restoreConsoleGuard?.()
+    currentShapeHookLifecycle = previousLifecycle
+  }
+}
+
+/**
+ * @param {string} hookName
+ * @returns {void}
+ */
+export function assertShapeHookLifecycleSupportsHooks(hookName) {
+  if (isProductionRuntime()) return
+  if (!currentShapeHookLifecycle) return
+  if (currentShapeHookLifecycle.name == "setup") return
+
+  throw buildShapeHookLifecycleHookError(hookName, currentShapeHookLifecycle)
+}
 
 /** @returns {number} */
 export function getRendering() {
@@ -95,6 +251,7 @@ export function resetSharedStateForTests() {
   setRenderingCallbacks([])
   setAfterPaintCallbacks([])
   setAfterPaintHandle(undefined)
+  currentShapeHookLifecycle = undefined
   deferredCallbackErrorReporter = defaultDeferredCallbackErrorReporter
 }
 

--- a/src/use-now.js
+++ b/src/use-now.js
@@ -1,4 +1,5 @@
 import {arrayReferenceDifferent} from "./diff-utils.js"
+import {assertShapeHookLifecycleSupportsHooks} from "./shared.js"
 import {useRef} from "react"
 
 /**
@@ -15,6 +16,8 @@ import {useRef} from "react"
  * @returns {void}
  */
 export default function useNow(callback, deps) {
+  assertShapeHookLifecycleSupportsHooks("useNow")
+
   /** @type {import("react").MutableRefObject<Array<unknown> | null>} */
   const prev = useRef(null)
 

--- a/src/use-shape.js
+++ b/src/use-shape.js
@@ -3,7 +3,7 @@ import resolveInitialStateValue from "./resolve-initial-state-value.js"
 import {useEffect, useMemo} from "react"
 import fetchingObject from "fetching-object"
 import {shapeComponent} from "./shape-component.js"
-import {enqueueRenderCallback, getRendering} from "./shared.js"
+import {assertShapeHookLifecycleSupportsHooks, enqueueRenderCallback, getRendering} from "./shared.js"
 import useState from "./use-state.js"
 
 class UseShapeState {
@@ -138,6 +138,8 @@ class UseShapeState {
  * @returns {UseShapeState}
  */
 function useShape(props, opts) {
+  assertShapeHookLifecycleSupportsHooks("useShape")
+
   // One counter per instance drives all re-renders; state values live on
   // shape.state so writes after unmount can update silently.
   const [, setUpdateCount] = useState(0)

--- a/src/use-state.js
+++ b/src/use-state.js
@@ -1,4 +1,4 @@
-import {enqueueRenderCallback, getRendering} from "./shared.js"
+import {assertShapeHookLifecycleSupportsHooks, enqueueRenderCallback, getRendering} from "./shared.js"
 import {useLayoutEffect, useRef, useState as reactUseState} from "react"
 
 /**
@@ -12,6 +12,8 @@ import {useLayoutEffect, useRef, useState as reactUseState} from "react"
  * @returns {[T, (newValue: SetStateAction<T>) => void]}
  */
 export default function useState(initialState) {
+  assertShapeHookLifecycleSupportsHooks("useState")
+
   const [state, setState] = reactUseState(initialState)
   /** @type {import("react").RefObject<boolean>} */
   const mountedRef = useRef(false)

--- a/tsconfig.hook-field-spec.json
+++ b/tsconfig.hook-field-spec.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "checkJs": false,
+    "strict": true,
+    "strictPropertyInitialization": true
+  },
+  "include": [
+    "spec/hook-field-typecheck.js",
+    "spec/hook-field-strict-property-initialization.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `ShapeHook.hookField()` for setup-assigned hook fields so strict property initialization can treat those fields as assigned.
- Track ShapeHook lifecycle invocation sites and throw actionable development-time errors when hooks are called from constructors or `refresh()`.
- Document `setup()` as the only supported hook-call lifecycle site and add strict typecheck/runtime coverage.

## Why

`setup()` is the only lifecycle path that runs unconditionally at the top level on every render. Constructors run inside `useMemo`, and `refresh()` skips the first render, so hooks in either place violate React hook ordering. The new helper preserves the existing runtime behavior while giving consumers a clean typed field initializer pattern.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test -- spec/shape-hook-spec.js spec/use-state-spec.js spec/use-now-spec.js spec/use-shape-spec.js`